### PR TITLE
Fixes #1107, Changed proxy_pass to telescope_production

### DIFF
--- a/nginx-production.conf
+++ b/nginx-production.conf
@@ -101,7 +101,7 @@ http {
     location /legacy {
       expires max;
       add_header Cache-Control "public, max-age=31536000, immutable";
-      proxy_pass http://telescope_staging:3000;
+      proxy_pass http://telescope_production:3000;
     }
 
     # Static content


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1107
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Changed proxy_pass from telescope_staging:3000 to telescope_production:3000 inside '/legacy'

I'm having a bit of trouble re-creating the `nginx` crash locally, some guidance would be great on that before merging. 
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)

